### PR TITLE
Extract artifacts into subdir

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -66,9 +66,10 @@ jobs:
 
       - name: Download Previous Build Artifacts
         if: ${{ inputs.artifact-name != '' }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}
+          path: artifacts
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v2
 
-      - name: Download Previous Build Artifacts
+      - name: Download Previous Build Artifacts to artifacts/
         if: ${{ inputs.artifact-name != '' }}
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
To avoid name collisions of artifacts vs. subdirs/files in the git repo, extract artifacts into a well-known subdirectory.

As far as I could see (via GitHub full-text search), this functionality was not used by any CI pipeline so this change shouldn't break anything.

Once merged into `main`, would you kindly update the tags in https://github.com/samply/beam/blob/main/.github/workflows/?