### PR TITLE
Allow to fetch ALL artifacts

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -64,11 +64,17 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v2
 
-      - name: Download Previous Build Artifacts to artifacts/
-        if: ${{ inputs.artifact-name != '' }}
+      - name: Download specific Build Artifact to artifacts/
+        if: ${{ inputs.artifact-name != '' && inputs.artifact-name != '*' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}
+          path: artifacts
+
+      - name: Download all Build Artifacts to artifacts/
+        if: ${{ inputs.artifact-name == '*' }}
+        uses: actions/download-artifact@v3
+        with:
           path: artifacts
 
       - name: Set up QEMU

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -45,7 +45,8 @@ on:
       # build-args:
       #   required: false
       #   type: list
-      # If your actions generate an artifact in a previous build step, you can tell this worflow to download it
+      # If your actions generate an artifact in a previous build step, you can tell this worflow to download it.
+      # '*' will download *ALL* build artifacts into named subdirectories.
       artifact-name:
         required: false
         type: string


### PR DESCRIPTION
Since we cannot specify multiple artifacts to download, allow `*` to download *all* artifacts (behaviour described here: https://github.com/actions/download-artifact#download-all-artifacts)

This shouldn't break anything, but please double-check. Then, after the merge please rename `get-all-artifacts` to `main` in https://github.com/samply/beam/blob/main/.github/workflows/rust.yml