### PR TITLE
Ignore security holes without available patches

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           image-ref: ${{ inputs.image-name }}
           format: template
+          ignore-unfixed: true
           template: '@/contrib/sarif.tpl'
           output: trivy-results.sarif
 


### PR DESCRIPTION
There is nothing we can do about security holes in libraries for which there is not even a fix, yet. These messages will just lead to "security fatigue".