### PR TITLE
fix: Tag Docker Images on Default Branch as latest

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -121,6 +121,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,format=long,prefix=${{ inputs.image-tag-prefix }}sha-
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
 
@@ -155,6 +157,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.2 - 2022-07-21]
+### Fixed
+- latest tag should now be created automatically on default branch, as intended
+## [1.3.1 - 2022-07-21]
+### Changed
+- Switched to new Trivy Syntax for exporting sarif security scan results
+## [1.3.0 - 2022-07-19]
+### Added
+- Added Syntax to Download all Artifacts from a Pipeline
+## [1.2.1 - 2022-07-18]
+### Changed
+- Security Scan for Images will now ignore unfixable issues
 ## [1.2.0 - 2022-07-15]
 ### Added
 - Documentation in docker-ci.yml


### PR DESCRIPTION
This should fix the behaviour intended for default branches. Before, the push of latest only happend then a new Git Tag was pushed, refer to: https://github.com/docker/metadata-action#latest-tag