### PR TITLE
Replaced Maven Test with Verify

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,8 +60,8 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-${{ inputs.java-distribution }}-${{ inputs.java-version }}-maven-${{ hashFiles('pom.xml') }}
 
-    - name: Run the unit tests
-      run: mvn --batch-mode ${{ inputs.maven-command-line-parameters }} test
+    - name: Run all Tests
+      run: mvn --batch-mode ${{ inputs.maven-command-line-parameters }} verify
 
       # Save the generated Maven Artifacts, for later processing in other steps
     - name: Save Package as Artifact


### PR DESCRIPTION
With Verify, the final package will be created (e.g. a JAR) and integrationstests will run