### PR TITLE
Increase timeout from 5 to 10 mins

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           image-ref: ${{ inputs.image-name }}
           format: sarif
+          timeout: '10m0s'
           ignore-unfixed: true
           output: trivy-results.sarif
 


### PR DESCRIPTION
Adds more time for Trivy sec scan. This currently fails on TransFAIR with a time limit of 5 mins.