### PR TITLE
Enable the use of build args in the docker action

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -46,9 +46,9 @@ on:
         default: "linux/amd64,linux/arm64/v8"
       # A list of build arguments, passed to the docker build
       # FIXME: GitHub Actions currently doesn't support list types on inputs. This needs to be parsed by us from string.
-      # build-args:
-      #   required: false
-      #   type: list
+      build-args:
+        required: false
+        type: string
       # If your actions generate an artifact in a previous build step, you can tell this worflow to download it.
       # '*' will download *ALL* build artifacts into named subdirectories.
       artifact-name:


### PR DESCRIPTION
I dont know why this was commented out but I looked at the source code of the docker/build-push-action which just parses the string it gets as a list/csv. And from what I saw if you specify a list in github workflows like that:
```
build-args: |
  FOO=bar
  BAR=foo
```
Seems to parse into something that docker/build-push-action understands.
It worked in this run for beam: https://github.com/samply/beam/actions/runs/5177665919