### PR TITLE
GHCR commit-based images & image tidying

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -65,6 +65,11 @@ on:
       push-to:
         required: true
         type: string
+      # delete GHCR images older than ... (default: "one year"; state "keep" to skip)
+      ghcr-retention-policy:
+        required: false
+        default: one year
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -72,6 +77,22 @@ on:
         required: true
 
 jobs:
+  tidy-ghcr:
+    name: Tidy GHCR images older than ${{ inputs.ghcr-retention-policy }}
+    runs-on: ubuntu-latest
+    if: ${{ inputs.ghcr-retention-policy != 'keep' }}
+
+    steps:
+      - name: Delete old images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}
+          cut-off: ${{ inputs.ghcr-retention-policy }} ago UTC
+          account-type: org
+          org-name: samply
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+
   build:
     name: Dockerize${{ inputs.binary-name && format(' ({0})', inputs.binary-name) }}${{ inputs.image-tag-suffix && format(' ({0})', inputs.image-tag-suffix) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -131,18 +131,18 @@ jobs:
           fi
 
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download specific Build Artifact to artifacts/
         if: ${{ inputs.artifact-name != '' && inputs.artifact-name != '*' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: artifacts
 
       - name: Download all Build Artifacts to artifacts/
         if: ${{ inputs.artifact-name == '*' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -158,13 +158,13 @@ jobs:
         run: ls -laR
         
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Export to Docker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         if: ${{ env.security-scan != 'false' }}
         with:
           context: ${{ inputs.build-context }}
@@ -190,10 +190,10 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
-      - name: Define Image Tags for Github Container Registry
-        id: docker-meta-ghcr
+      - name: "GHCR: Define Image Tags (primary)"
+        id: docker-meta-ghcr-primary
         if: env.ghcr
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             "ghcr.io/${{ inputs.image-name }}"
@@ -204,36 +204,47 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,format=long,prefix=${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}sha-
+            type=sha,prefix=commit-${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}commit-
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 
-      - name: Login to Github Container Registry
-        if: env.ghcr
-        uses: docker/login-action@v1
+      - name: "GHCR: Define Image Tags (commit-based only)"
+        id: docker-meta-ghcr-commit
+        if: env.ghcr != 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            "ghcr.io/${{ inputs.image-name }}"
+          tags: |
+            type=sha,prefix=commit-${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}
+          flavor: |
+            prefix=${{ inputs.image-tag-prefix }},onlatest=true
+            suffix=${{ inputs.image-tag-suffix }},onlatest=true
+
+      - name: "GHCR: Login"
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Image to Github Container Registry
-        if: env.ghcr
-        uses: docker/build-push-action@v2
+      - name: "GHCR: Build and Push"
+        uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.build-context }}
           file: ${{ inputs.build-file }}
           push: true
           platforms: ${{ env.build_platforms }}
           build-args: ${{ inputs.build-args }}
-          labels: ${{ steps.docker-meta-ghcr.outputs.labels }}
-          tags: ${{ steps.docker-meta-ghcr.outputs.tags }}
+          labels: ${{ steps.docker-meta-ghcr-primary.outputs.labels }}${{ steps.docker-meta-ghcr-commit.outputs.labels }}
+          tags: ${{ steps.docker-meta-ghcr-primary.outputs.tags }}${{ steps.docker-meta-ghcr-commit.outputs.tags }}
 
-      - name: Generate Image Tags for Docker Hub
+      - name: "Docker Hub: Generate Image Tags"
         id: docker-meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         if: env.dockerhub && github.event_name != 'pull_request'
         with:
           images: |
@@ -250,15 +261,15 @@ jobs:
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: "Docker Hub: Login"
+        uses: docker/login-action@v3
         if: env.dockerhub && github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push Image to Docker Hub
-        uses: docker/build-push-action@v2
+      - name: "Docker Hub: Build and Push"
+        uses: docker/build-push-action@v5
         if: env.dockerhub && github.event_name != 'pull_request'
         with:
           context: ${{ inputs.build-context }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,11 @@ on:
         description: "Set to none, dockerhub, ghcr or both"
         required: true
         type: string
+      # delete GHCR images older than ... (default: "one year"; state "keep" to skip)
+      ghcr-retention-policy:
+        required: false
+        default: one year
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -53,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   build:
@@ -99,7 +104,7 @@ jobs:
           else
             echo "profilestr=--profile $PROFILE" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 #      - uses: actions-rs/toolchain@v1
 #        if: false
 #        with:
@@ -196,7 +201,7 @@ jobs:
 
     # This workflow defines how a maven package is built, tested and published.
     # Visit: https://github.com/samply/github-workflows/blob/develop/.github/workflows/docker-ci.yml, for more information
-    uses: samply/github-workflows/.github/workflows/docker-ci.yml@ghcr-commit
+    uses: samply/github-workflows/.github/workflows/docker-ci.yml@main
     with:
       # The Docker Hub Repository you want eventually push to, e.g samply/share-client
       image-name: ${{ inputs.image-prefix }}${{ matrix.components }}
@@ -219,6 +224,7 @@ jobs:
       artifact-name: '*'
       binary-name: ${{ matrix.components }}
       push-to: ${{ inputs.push-to }}
+      ghcr-retention-policy: ${{ inputs.ghcr-retention-policy }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,7 +136,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
       - name: Upload (bins)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.arch }}-${{ matrix.features }}
           if-no-files-found: error
@@ -144,7 +144,7 @@ jobs:
             ${{ env.bins }}
       - name: Upload (test, native only)
         if: matrix.arch == 'amd64'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: testbinaries-${{ matrix.arch }}-${{ matrix.features }}
           if-no-files-found: error
@@ -163,12 +163,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download bins
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-amd64-${{ matrix.features }}
           path: artifacts/binaries-amd64/
       - name: Download tests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: testbinaries-amd64-${{ matrix.features }}
           path: testbinaries/
@@ -196,7 +196,7 @@ jobs:
 
     # This workflow defines how a maven package is built, tested and published.
     # Visit: https://github.com/samply/github-workflows/blob/develop/.github/workflows/docker-ci.yml, for more information
-    uses: samply/github-workflows/.github/workflows/docker-ci.yml@main
+    uses: samply/github-workflows/.github/workflows/docker-ci.yml@ghcr-commit
     with:
       # The Docker Hub Repository you want eventually push to, e.g samply/share-client
       image-name: ${{ inputs.image-prefix }}${{ matrix.components }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.1 - 2024-04-11]
+### Added
+- Always push GHCR images based on commit id, e.g. `samply/component:commit-123456`
+- Cleanup old GHCR images (default: keep one year)
 ## [1.4.0 - 2024-04-04]
 ### Added
 - New **mandatory** parameter push-to for docker-ci.yml


### PR DESCRIPTION
## [1.4.1 - 2024-04-11]
### Added
- Always push GHCR images based on commit id, e.g. `samply/component:commit-123456`
- Cleanup old GHCR images (default: keep one year)
