### PR TITLE
fix(trivy): add fallback vulnerability registry

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -222,9 +222,11 @@ jobs:
           timeout: '10m0s'
           ignore-unfixed: true
           output: trivy-results.sarif
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload Trivy Scan Results to GitHub Security Tab
-        uses: github/codeql-action/upload-sarif@codeql-bundle-20211208
+        uses: github/codeql-action/upload-sarif@v3
         if: ${{ env.security-scan != 'false' }}
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy-action/issues/389

Not sure why we had the weird tag for the upload action I changed it as the GitHub editor highlighted it.