### PR TITLE
chore: update upload-artifact v3 -> v4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,7 +71,7 @@ jobs:
       # Save the generated Maven Artifacts, for later processing in other steps
     - name: Save Package as Artifact
       if: ${{ inputs.artifact-name != '' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}


### PR DESCRIPTION
The v3 version will be no longer supported by 1st December. The update guide mentions some breaking changes but they shouldn't affect us: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
The part about not uploading to the same artifact is explained in more detail down below and clarifies in my understanding, that you should just not push to the same artifact name multiple times in one workflow run (e.g. by different jobs): https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact