### PR TITLE
Check Rust code style with cargo fmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: one year
         type: string
+      cargo-fmt-check:
+        description: "Whether to check code style with cargo fmt"
+        required: false
+        type: boolean
+        default: false
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -189,6 +194,15 @@ jobs:
         if: ${{ inputs.test-via-script }}
         run: |
           ./dev/test ci ${{ matrix.features && format('--features {0}', matrix.features) }}
+
+  cargo-fmt-check:
+    name: Cargo fmt check
+    if: ${{ inputs.cargo-fmt-check }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all --check
 
   docker:
     name: Docker


### PR DESCRIPTION
This PR adds a job to the Rust CI that checks whether the code style confirms to the formatting rules of [rustfmt](https://github.com/rust-lang/rustfmt). The input `cargo-fmt-check: true` has to be set explicitly, otherwise the check is not performed. This means that existing repositories that use the Rust CI are not impacted unless they explicitly opt in.

~~I bumped the version of EmbarkStudios/cargo-deny-action to fix an unrelated issue. Newer Cargo.lock files (version >=4) are not supported by the old version of EmbarkStudios/cargo-deny-action.~~