### PR TITLE
Allow unmaintained dependencies in deny.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,9 @@ jobs:
           github = ["samply"]
           [advisories]
           unmaintained = "none"
+          ignore = [
+            "RUSTSEC-2023-0071"
+          ]
           EOF
     - uses: EmbarkStudios/cargo-deny-action@v2
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,8 @@ jobs:
           ]
           [sources.allow-org]
           github = ["samply"]
+          [advisories]
+          unmaintained = "none"
           EOF
     - uses: EmbarkStudios/cargo-deny-action@v2
 


### PR DESCRIPTION
Focus needs an urgent build and we need this to get focus to build a docker image. Also I think we mostly want deny.toml for license checks so this should hopefully be okay.