### PR TITLE
Only clean GHCR images if we actually push to GHCR

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -84,7 +84,7 @@ jobs:
   tidy-ghcr:
     name: Tidy GHCR images (${{ inputs.image-name }})
     runs-on: ubuntu-latest
-    if: ${{ inputs.ghcr-retention-policy != 'keep' }}
+    if: ${{ inputs.ghcr-retention-policy != 'keep' && (inputs.push-to == 'ghcr' || inputs.push-to == 'both') }}
 
     steps:
       - name: Compute image name


### PR DESCRIPTION
We have the issue in https://github.com/samply/ccp-explorer and https://github.com/samply/organoid-dashboard that the GHCR cleaning job fails because GHCR was never set up for those repos. We could set `ghcr-retention-policy: keep` in the repositories that have this issue but I think doing it centrally like this PR is cleaner.