### PR TITLE
Fix nightly build pattern

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -239,7 +239,7 @@ jobs:
           images: |
             "ghcr.io/${{ inputs.image-name }}"
           tags: |
-            type=schedule
+            type=schedule,pattern=nightly
             type=ref,event=branch
             type=ref,event=pr,prefix=${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}pr-
             type=semver,pattern={{version}}
@@ -297,7 +297,7 @@ jobs:
           images: |
             ${{ inputs.image-name }}
           tags: |
-            type=schedule
+            type=schedule,pattern=nightly
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -338,7 +338,7 @@ jobs:
           images: |
             docker.verbis.dkfz.de/${{ inputs.image-name }}
           tags: |
-            type=schedule
+            type=schedule,pattern=nightly
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Currently, the scheduled builds tag the image as nightly, branchname, and latest. This can lead to a mistagging. This PR should remove the branchname tag.