### PR TITLE
chore: allow `CDLA-Permissive-2.0`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,7 @@ jobs:
               "Zlib",
               "OpenSSL",
               "MPL-2.0",
+              "CDLA-Permissive-2.0"
           ]
           [sources.allow-org]
           github = ["samply"]


### PR DESCRIPTION
Required by `reqwest` with `rustls-tls` enabled.