### PR TITLE
Updated latest tag Behaviour

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -248,8 +248,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=commit-${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # set latest tag on new version tags
+            type=match,pattern=v?\d+.\d+.\d+.,value=latest
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
@@ -304,8 +304,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # set latest tag on new version tags
+            type=match,pattern=v?\d+.\d+.\d+.,value=latest
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
@@ -345,8 +345,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # set latest tag on new version tags
+            type=match,pattern=v?\d+.\d+.\d+.,value=latest
           flavor: |
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true


### PR DESCRIPTION
Currently, the latest tag is always added to the images from the repositories default branch.
With this change, the latest tag will only be updated when pushing a git tag matching the semantic versioning scheme.