### PR TITLE
Docker CI: make `latest` tag point to latest release

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -8,8 +8,8 @@
 #     * Running the action on push of a semver tag of the form "v<major>.<minor>.<patch>" without specified pre-release adds the tags "<major>" (if not 0), "<major>.<minor>", "<major>.<minor>.<patch>", and "latest"
 #     * Running the action on push of a semver tag of the form "v<major>.<minor>.<patch>-<prerelease>" adds the tag "<major>.<minor>.<patch>-<prerelease>"
 #     * Running the action on a scheduled basis adds the tag "nightly"
-#     * If GHCR is enabled, running the action on pull request pushes to GHCR with the tag "pr-<pr-number>" but does not push to Docker Hub and VerbIS Harbor
-#     * If GHCR is enabled, always adds the tag "sha-<short-commit-sha>" on GHCR but not on Docker Hub and VerbIS Harbor
+#     * Running the action on pull request pushes only to GHCR (if enabled) with the tag "pr-<pr-number>"
+#     * When pushing to GHCR (if enabled) always adds the tag "sha-<short-commit-sha>"
 # 5) Rebuild the image for all necessary platforms an publish it based on the applied tags from 4.
 #
 # An usage example for this action is provided in the samply organization: https://github.com/samply/.github/blob/main/workflow-templates/docker-ci-template.yml

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -4,11 +4,12 @@
 # 2) Scan the image for vulnerabilities with trivy (see https://github.com/aquasecurity/trivy)
 # 3) Upload the scan results from step 2 to the github security tab of the repository
 # 4) Generating appropriate image tags for publishing using the docker/metadata-action. Following Rules are applied:
-#     1. Running the action on push to the main branch will trigger tagging image as latest
-#     2. Running the action on push to a git branch trigger tagging image as "<branchname>"
-#     3. Running the action on push of a git tag matching the semver schema will trigger tagging image with {MAJOR}, {MAJOR}.{MINOR} and {MAJOR}.{MINOR}.{PATCH}
-#     4. Running the action on push to a pull request, will trigger tagging for the github container registry with ghcr.io/<repository-name>/<pr-reference>. This will be skipped for private repositories.
-#     5. Running the action on a scheduled basis will trigger tagging images with "nightly".
+#     * Running the action on push to a git branch adds the tag "<branchname>"
+#     * Running the action on push of a semver tag of the form "v<major>.<minor>.<patch>" without specified pre-release adds the tags "<major>" (if not 0), "<major>.<minor>", "<major>.<minor>.<patch>", and "latest"
+#     * Running the action on push of a semver tag of the form "v<major>.<minor>.<patch>-<prerelease>" adds the tag "<major>.<minor>.<patch>-<prerelease>"
+#     * Running the action on a scheduled basis adds the tag "nightly"
+#     * If GHCR is enabled, running the action on pull request pushes to GHCR with the tag "pr-<pr-number>" but does not push to Docker Hub and VerbIS Harbor
+#     * If GHCR is enabled, always adds the tag "sha-<short-commit-sha>" on GHCR but not on Docker Hub and VerbIS Harbor
 # 5) Rebuild the image for all necessary platforms an publish it based on the applied tags from 4.
 #
 # An usage example for this action is provided in the samply organization: https://github.com/samply/.github/blob/main/workflow-templates/docker-ci-template.yml
@@ -233,7 +234,7 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
-      - name: "GHCR: Define Image Tags (primary)"
+      - name: "GHCR: Generate Image Tags"
         id: docker-meta-ghcr-primary
         if: env.ghcr
         uses: docker/metadata-action@v5
@@ -243,14 +244,14 @@ jobs:
           tags: |
             type=schedule,pattern=nightly
             type=ref,event=branch
-            type=ref,event=pr,prefix=${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}pr-
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=commit-${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha
           flavor: |
+            # adds "latest" tag if any rule of type=ref,event=tag, type=semver, type=pep440, or type=match is specified and matches (only type=semver is specified here)
+            latest=auto
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 
@@ -290,10 +291,10 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
           flavor: |
+            # adds "latest" tag if any rule of type=ref,event=tag, type=semver, type=pep440, or type=match is specified and matches (only type=semver is specified here)
+            latest=auto
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 
@@ -331,10 +332,10 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
           flavor: |
+            # adds "latest" tag if any rule of type=ref,event=tag, type=semver, type=pep440, or type=match is specified and matches (only type=semver is specified here)
+            latest=auto
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -254,19 +254,6 @@ jobs:
             prefix=${{ inputs.image-tag-prefix }},onlatest=true
             suffix=${{ inputs.image-tag-suffix }},onlatest=true
 
-      - name: "GHCR: Define Image Tags (commit-based only)"
-        id: docker-meta-ghcr-commit
-        if: env.ghcr != 'true'
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            "ghcr.io/${{ inputs.image-name }}"
-          tags: |
-            type=sha,prefix=commit-${{ inputs.image-tag-prefix }},suffix=${{ inputs.image-tag-suffix }}
-          flavor: |
-            prefix=${{ inputs.image-tag-prefix }},onlatest=true
-            suffix=${{ inputs.image-tag-suffix }},onlatest=true
-
       - name: "GHCR: Login"
         if: env.ghcr
         uses: docker/login-action@v3


### PR DESCRIPTION
Currently the `latest` tag is added to images from the repositories default branch (usually `main` or `develop`). With this change, the `latest` tag will only be updated when pushing a git tag matching the semantic versioning scheme. This effectively means that the `latest` tag will always refer to the latest release.

Impact on existing projects:
* In places where `main` or `develop` tags are used (e.g. `samply/foobar:main`) there is no change. These will continue to point to the latest commit of the `main` or `develop` branch respectively.
* In places where the `latest` tag is used (e.g. `samply/foobar` and  `samply/foobar:latest`) the meaning changes. Previously they were pointing to the latest commit of the default branch, after this PR they will point to the latest release. If the latest commit is wanted the tag must be changed to a branch name.

Motivation:
* It allows projects to switch over to a single-branch model, where development happens on the `main` branch and releases are made through git tags only (as opposed to developing in `develop` and making releases by merging into `main`).
* Aligns our projects with the de facto standard meaning of the `latest` tag across the Docker landscape.

Details:
* Updated the tagging rules to be in line with the [semver example](https://github.com/docker/metadata-action?tab=readme-ov-file#semver) from the docker/metadata-action readme.
* Disabled `<major>` tagging when major is 0 as suggested in docker/metadata-action readme.
* Removed `suffix=${{ inputs.image-tag-suffix }}pr-` as this was bogus (`-` placed incorrectly) and not needed as global prefix and suffix applies always.
* Removed unnecessary actions step (see commit message of first commit)

