### PR TITLE
Allow BSD-2-Clause license

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,6 +76,7 @@ jobs:
               "MIT",
               "Apache-2.0",
               "ISC",
+              "BSD-2-Clause",
               "BSD-3-Clause",
               "Unicode-DFS-2016",
               "Unicode-3.0",


### PR DESCRIPTION
We already allow BSD-3-Clause which is a stricter version of 2. And 2 is now required by a dep of simple-jwt which is used by beam. See https://github.com/samply/beam/actions/runs/21028354613/job/60458158950