### PR TITLE
Also add prefix for PR tags

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -264,7 +264,7 @@ jobs:
             # Branch pushes
             type=ref,event=branch
             # PRs
-            type=ref,event=pr
+            type=ref,event=pr,prefix=${{ inputs.image-tag-prefix }}pr-
             # Semver tags
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Pull request tags like `pr-123` are currently missing the image-tag-prefix.  There is a long standing issue for this: https://github.com/docker/metadata-action/issues/270. This is a workaround for that issue.